### PR TITLE
Phonetic option matching

### DIFF
--- a/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
+++ b/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
@@ -66,7 +66,7 @@ private[excel] object ExcelParserOptions {
     keys.foreach(key => {
       val encodedKey = encoder.encode(key)
       if (!mappings.values.exists(_.compareToIgnoreCase(key) == 0) && mappings.contains(encodedKey)) {
-        buffer.append(s"Invalid option '$key', did you mean '${mappings(encodedKey)}'?")
+        buffer.append(s"Invalid option '${key.toLowerCase}', did you mean '${mappings(encodedKey)}'?")
       }
     })
 

--- a/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
+++ b/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
@@ -16,7 +16,11 @@
 
 package com.elastacloud.spark.excel
 
+import org.apache.commons.codec.language.DoubleMetaphone
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.collection.mutable.ArrayBuffer
 
 /**
  * Defines the Excel parser options
@@ -36,6 +40,39 @@ private[excel] case class ExcelParserOptions(workbookPassword: Option[String] = 
                                              includeSheetName: Boolean = false)
 
 private[excel] object ExcelParserOptions {
+  private val encoder = new DoubleMetaphone()
+
+  /**
+   * Valid parser options and their phonetic values
+   */
+  private val mappings = Map[String, String](
+    encoder.encode("workbookPassword") -> "workbookPassword",
+    encoder.encode("sheetNamePattern") -> "sheetNamePattern",
+    encoder.encode("cellAddress") -> "cellAddress",
+    encoder.encode("headerRowCount") -> "headerRowCount",
+    encoder.encode("maxRowCount") -> "maxRowCount",
+    encoder.encode("includeSheetName") -> "includeSheetName"
+  )
+
+  /**
+   * Checks the provided set of keys for invalid options and attempts to match again
+   * valid options.
+   * @param keys collection of keys to valid
+   * @return An [[Option]] containing a string if there are errors, or [[None]]
+   */
+  private def checkInvalidOptions(keys: Set[String]): Option[Seq[String]] = {
+    val buffer = new ArrayBuffer[String]()
+
+    keys.foreach(key => {
+      val encodedKey = encoder.encode(key)
+      if (!mappings.values.exists(_.compareToIgnoreCase(key) == 0) && mappings.contains(encodedKey)) {
+        buffer.append(s"Invalid option '$key', did you mean '${mappings(encodedKey)}'?")
+      }
+    })
+
+    if (buffer.isEmpty) None else Some(buffer)
+  }
+
   /**
    * Creates a new [[ExcelParserOptions]] object from a [[CaseInsensitiveStringMap]] collection
    *
@@ -43,6 +80,11 @@ private[excel] object ExcelParserOptions {
    * @return an [[ExcelParserOptions]] object
    */
   def from(options: CaseInsensitiveStringMap): ExcelParserOptions = {
+    checkInvalidOptions(options.keySet().toSet) match {
+      case Some(errors) => throw new ExcelParserOptionsException(s"Unable to parse options:\n${errors.mkString("\n")}")
+      case _ =>
+    }
+
     val worksheetPassword = if (options.containsKey("workbookPassword")) {
       Some(options.get("workbookPassword"))
     } else {
@@ -59,7 +101,18 @@ private[excel] object ExcelParserOptions {
     )
   }
 
+  /**
+   * Creates a new [[ExcelParserOptions]] object from a [[Map]] collection
+   *
+   * @param options the map of options to read from
+   * @return an [[ExcelParserOptions]] object
+   */
   def from(options: Map[String, String]): ExcelParserOptions = {
+    checkInvalidOptions(options.keySet) match {
+      case Some(errors) => throw new ExcelParserOptionsException(s"Unable to parse options:\n${errors.mkString("\n")}")
+      case _ =>
+    }
+
     val worksheetPassword = if (options.keys.exists(_.compareToIgnoreCase("workbookPassword") == 0)) {
       Some(options("workbookPassword"))
     } else {

--- a/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptionsException.scala
+++ b/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptionsException.scala
@@ -1,0 +1,3 @@
+package com.elastacloud.spark.excel
+
+final class ExcelParserOptionsException(message: String) extends Exception(message) {}

--- a/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
@@ -60,19 +60,19 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
       "workbookPasword" -> "abc123",
       "sheetNamPatten" -> "Sheet[12]",
       "cellAdres" -> "B3",
-      "hdrRowCount" -> "12",
+      "headerCount" -> "12",
       "maxRowCont" -> "2000",
       "includShetNam" -> "true"
     ).asJava)
 
     val exception = the[ExcelParserOptionsException] thrownBy ExcelParserOptions.from(input)
 
-    exception.getMessage.contains("Invalid option 'workbookPasword' did you mean 'workbookPassword'?")
-    exception.getMessage.contains("Invalid option 'sheetNamPatten' did you mean 'sheetNamePattern'?")
-    exception.getMessage.contains("Invalid option 'cellAdres' did you mean 'cellAddress'?")
-    exception.getMessage.contains("Invalid option 'hdrRowCount' did you mean 'headerRowCount'?")
-    exception.getMessage.contains("Invalid option 'maxRowCont' did you mean 'maxRowCount'?")
-    exception.getMessage.contains("Invalid option 'includShetNam' did you mean 'includeSheetName'?")
+    exception.getMessage.contains("Invalid option 'workbookpasword', did you mean 'workbookPassword'?") should be(true)
+    exception.getMessage.contains("Invalid option 'sheetnampatten', did you mean 'sheetNamePattern'?") should be(true)
+    exception.getMessage.contains("Invalid option 'celladres', did you mean 'cellAddress'?") should be(true)
+    exception.getMessage.contains("Invalid option 'headercount', did you mean 'headerRowCount'?") should be(true)
+    exception.getMessage.contains("Invalid option 'maxrowcont', did you mean 'maxRowCount'?") should be(true)
+    exception.getMessage.contains("Invalid option 'includshetnam', did you mean 'includeSheetName'?") should be(true)
   }
 
   it should "ignore options which are invalid and not close in spelling to valid options" in {

--- a/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
@@ -1,0 +1,122 @@
+package com.elastacloud.spark.excel
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
+  behavior of "Creating a default instance"
+
+  it should "use default values" in {
+    val options = new ExcelParserOptions()
+
+    options.workbookPassword should be(None)
+    options.sheetNamePattern shouldBe empty
+    options.cellAddress should be("A1")
+    options.headerRowCount should be(1)
+    options.maxRowCount should be(1000)
+    options.includeSheetName should be(false)
+  }
+
+  behavior of "Creating from a case insensitive map"
+
+  it should "use default values for an empty map" in {
+    val input = new CaseInsensitiveStringMap(Map[String, String]().asJava)
+
+    val options = ExcelParserOptions.from(input)
+
+    options.workbookPassword should be(None)
+    options.sheetNamePattern shouldBe empty
+    options.cellAddress should be("A1")
+    options.headerRowCount should be(1)
+    options.maxRowCount should be(1000)
+    options.includeSheetName should be(false)
+  }
+
+  it should "extract values from the map" in {
+    val input = new CaseInsensitiveStringMap(Map[String, String](
+      "workbookPassword" -> "abc123",
+      "sheetNamePattern" -> "Sheet[12]",
+      "cellAddress" -> "B3",
+      "headerRowCount" -> "12",
+      "maxRowCount" -> "2000",
+      "includeSheetName" -> "true"
+    ).asJava)
+
+    val options = ExcelParserOptions.from(input)
+
+    options.workbookPassword should be(Some("abc123"))
+    options.sheetNamePattern should be("Sheet[12]")
+    options.cellAddress should be("B3")
+    options.headerRowCount should be(12)
+    options.maxRowCount should be(2000)
+    options.includeSheetName should be(true)
+  }
+
+  it should "provide useful error information if options are slightly mis-spelt" in {
+    val input = new CaseInsensitiveStringMap(Map[String, String](
+      "workbookPasword" -> "abc123",
+      "sheetNamPatten" -> "Sheet[12]",
+      "cellAdres" -> "B3",
+      "hdrRowCount" -> "12",
+      "maxRowCont" -> "2000",
+      "includShetNam" -> "true"
+    ).asJava)
+
+    val exception = the[ExcelParserOptionsException] thrownBy ExcelParserOptions.from(input)
+
+    exception.getMessage.contains("Invalid option 'workbookPasword' did you mean 'workbookPassword'?")
+    exception.getMessage.contains("Invalid option 'sheetNamPatten' did you mean 'sheetNamePattern'?")
+    exception.getMessage.contains("Invalid option 'cellAdres' did you mean 'cellAddress'?")
+    exception.getMessage.contains("Invalid option 'hdrRowCount' did you mean 'headerRowCount'?")
+    exception.getMessage.contains("Invalid option 'maxRowCont' did you mean 'maxRowCount'?")
+    exception.getMessage.contains("Invalid option 'includShetNam' did you mean 'includeSheetName'?")
+  }
+
+  it should "ignore options which are invalid and not close in spelling to valid options" in {
+    val input = new CaseInsensitiveStringMap(Map[String, String](
+      "pwd" -> "abc123"
+    ).asJava)
+
+    val options = ExcelParserOptions.from(input)
+
+    options.workbookPassword should be(None)
+  }
+
+  behavior of "Creating from a string map"
+
+  it should "use default values for an empty map" in {
+    val input = Map[String, String]()
+
+    val options = ExcelParserOptions.from(input)
+
+    options.workbookPassword should be(None)
+    options.sheetNamePattern shouldBe empty
+    options.cellAddress should be("A1")
+    options.headerRowCount should be(1)
+    options.maxRowCount should be(1000)
+    options.includeSheetName should be(false)
+  }
+
+  it should "extract values from the map" in {
+    val input = Map[String, String](
+      "workbookPassword" -> "abc123",
+      "sheetNamePattern" -> "Sheet[12]",
+      "cellAddress" -> "B3",
+      "headerRowCount" -> "12",
+      "maxRowCount" -> "2000",
+      "includeSheetName" -> "true"
+    )
+
+    val options = ExcelParserOptions.from(input)
+
+    options.workbookPassword should be(Some("abc123"))
+    options.sheetNamePattern should be("Sheet[12]")
+    options.cellAddress should be("B3")
+    options.headerRowCount should be(12)
+    options.maxRowCount should be(2000)
+    options.includeSheetName should be(true)
+  }
+}

--- a/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
@@ -7,9 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 
 class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
-  behavior of "Creating a default instance"
-
-  it should "use default values" in {
+  "Creating a default instance" should "use default values" in {
     val options = new ExcelParserOptions()
 
     options.workbookPassword should be(None)
@@ -20,9 +18,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.includeSheetName should be(false)
   }
 
-  behavior of "Creating from a case insensitive map"
-
-  it should "use default values for an empty map" in {
+  "Creating from a case insensitive map" should "use default values for an empty map" in {
     val input = new CaseInsensitiveStringMap(Map[String, String]().asJava)
 
     val options = ExcelParserOptions.from(input)
@@ -85,9 +81,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.workbookPassword should be(None)
   }
 
-  behavior of "Creating from a string map"
-
-  it should "use default values for an empty map" in {
+  "Creating from a string map" should "use default values for an empty map" in {
     val input = Map[String, String]()
 
     val options = ExcelParserOptions.from(input)


### PR DESCRIPTION
Closes #2 by implementing phonetic checking of options provided by the user, generating an error message containing what the spelling should have been