### PR TITLE
Upgrade POI and introduce additional data types for user defined schemas

### DIFF
--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, 3.2.1 ]
+        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1 ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -6,50 +6,50 @@ on:
   pull_request:
     branches: [ main, development ]
   workflow_dispatch:
-    
+
 
 jobs:
   build:
     strategy:
       matrix:
-        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0 ]
-  
+        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.2.0, 3.2.1 ]
+
     runs-on: ubuntu-latest
 
     steps:
-    
-    - name: Checkout with LFS
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-    
-    - name: Set up JDK 8
-      uses: actions/setup-java@v2
-      with:
-        java-version: '8'
-        distribution: 'adopt'
-    
-    - name: Run tests and produce coverage
-      run: sbt -DsparkVersion="${{matrix.sparkVersion}}" clean coverageOn test coverageReport
-    
-    - name: Upload coverage to CodeCov
-      uses: codecov/codecov-action@v1.5.2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/coverage-report/cobertura.xml
-        env_vars: ${{ matrix.sparkVersion }}
-        fail_ci_if_error: true
-        name: spark-excel
-        path_to_write_report: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/coverage-report/codecov_report.txt
-        verbose: true
 
-    - name: Create assembly
-      if: ${{ github.event_name != 'pull_request' }}
-      run: sbt -DsparkVersion="${{matrix.sparkVersion}}" clean coverageOff assembly
-    
-    - name: Upload the package
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: actions/upload-artifact@v2.2.4
-      with:
-        path: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/spark-excel*.jar
-        if-no-files-found: warn
+      - name: Checkout with LFS
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Run tests and produce coverage
+        run: sbt -DsparkVersion="${{matrix.sparkVersion}}" clean coverageOn test coverageReport
+
+      - name: Upload coverage to CodeCov
+        uses: codecov/codecov-action@v1.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/coverage-report/cobertura.xml
+          env_vars: ${{ matrix.sparkVersion }}
+          fail_ci_if_error: true
+          name: spark-excel
+          path_to_write_report: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/coverage-report/codecov_report.txt
+          verbose: true
+
+      - name: Create assembly
+        if: ${{ github.event_name != 'pull_request' }}
+        run: sbt -DsparkVersion="${{matrix.sparkVersion}}" clean coverageOff assembly
+
+      - name: Upload the package
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          path: ./target/spark-${{ matrix.sparkVersion }}/scala-2.12/spark-excel*.jar
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ write data sources using the
 Spark [DataSourceV2](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/sources/v2/DataSourceV2.html)
 APIs. This is based on the [Apache POI](https://poi.apache.org/) library which provides the means to read Excel files.
 
+_N.B._ This project is only intended as a reader and is opinionated about this. There are no plans to implement writer
+functionality into the project.
+
 ## Important
 
 This repository makes use of [Git-LFS](https://git-lfs.github.com/) to track the Excel files for unit tests. This allows
@@ -42,9 +45,9 @@ val df = spark.read
 ```python
 # Python
 df = spark.read
-    .format("com.elastacloud.spark.excel")
-    .option("cellAddress", "A1")
-    .load("/path/to/my_file.xlsx")
+.format("com.elastacloud.spark.excel")
+.option("cellAddress", "A1")
+.load("/path/to/my_file.xlsx")
 ```
 
 A short name has been provided for convenience, as well as convenience method (Scala only currently).
@@ -90,12 +93,12 @@ maxRowCount      | Int     | 1000    | Number of records to read to infer the sc
 ```scala
 val df = spark.read
   .format("com.elastacloud.spark.excel")
-  .option("cellAddress", "C3")                 // The first line of the table starts at cell C3
-  .option("headerRowCount", 2)                 // The first 2 lines of the table make up the header row
-  .option("includeSheetName", value = true)    // Include the sheet name(s) the data has come from
-  .option("workbookPassword", "AP@55w0rd")     // Use this password to open the workbook with
+  .option("cellAddress", "C3") // The first line of the table starts at cell C3
+  .option("headerRowCount", 2) // The first 2 lines of the table make up the header row
+  .option("includeSheetName", value = true) // Include the sheet name(s) the data has come from
+  .option("workbookPassword", "AP@55w0rd") // Use this password to open the workbook with
   .option("sheetNamePattern", """Sheet[13]""") // Read data from all sheets matching this pattern (e.g. Sheet1 and Sheet3)
-  .option("maxRowCount", 10)                    // Read only the first 10 records to determine the schema of the data
+  .option("maxRowCount", 10) // Read only the first 10 records to determine the schema of the data
   .load("/path/to/file.xlsx")
 ```
 
@@ -137,8 +140,9 @@ set.
 If, for example, you wanted to include sheet names for the next 3 years (assuming the year is currently 2021) then you
 could provide a pattern of `202[234]`. This would ignore any sheets for other years, summary sheets etc...
 
-Often when using this option it is useful to include the sheet name so that the original context is not lost, in the same
-way you might want to include the source file name when reading from multiple files. And so the code might read like.
+Often when using this option it is useful to include the sheet name so that the original context is not lost, in the
+same way you might want to include the source file name when reading from multiple files. And so the code might read
+like.
 
 ```scala
 val df = spark.read

--- a/build.ps1
+++ b/build.ps1
@@ -14,23 +14,26 @@
     https://www.elastacloud.com
 #>
 
-$versions = @("3.0.1", "3.0.2", "3.1.1", "3.1.2")
+$versions = @("3.0.1", "3.0.2", "3.0.3", "3.1.1", "3.1.2", "3.2.0", "3.2.1")
 $jarPath = "./target/jars"
 $covPath = "./target/coverage"
 
 Write-Host "Clearing existing artefacts" -ForegroundColor Green
-if (Test-Path $jarPath) {
+if (Test-Path $jarPath)
+{
     Remove-Item -Path $jarPath -Force -Recurse
 }
 
-if (Test-Path $covPath) {
+if (Test-Path $covPath)
+{
     Remove-Item -Path $covPath -Force -Recurse
 }
 
 New-Item -Path $jarPath -ItemType Directory
 New-Item -Path $covPath -ItemType Directory
 
-foreach ($version in $versions) {
+foreach ($version in $versions)
+{
     Write-Host "Building for Spark version: $version" -ForegroundColor Green
     & sbt -DsparkVersion="$version" clean coverageOn test coverageReport coverageOff assembly
 }

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,7 @@
     https://www.elastacloud.com
 #>
 
-$versions = @("3.0.1", "3.0.2", "3.0.3", "3.1.1", "3.1.2", "3.2.0", "3.2.1")
+$versions = @("3.0.1", "3.0.2", "3.0.3", "3.1.1", "3.1.2", "3.1.3", "3.2.0", "3.2.1")
 $jarPath = "./target/jars"
 $covPath = "./target/coverage"
 

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,7 @@ addArtifact(Compile / assembly / artifact, assembly)
 // Define common settings for the library
 val commonSettings = Seq(
   sparkVersion := System.getProperty("sparkVersion", "3.2.1"),
-  sparkExcelVersion := "0.1.8-SNAPSHOT",
+  sparkExcelVersion := "0.1.8",
   version := s"${sparkVersion.value}_${sparkExcelVersion.value}",
   scalaVersion := {
     if (sparkVersion.value < "3.2.0") {

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ addArtifact(Compile / assembly / artifact, assembly)
 // Define common settings for the library
 val commonSettings = Seq(
   sparkVersion := System.getProperty("sparkVersion", "3.2.0"),
-  sparkExcelVersion := "0.1.7",
+  sparkExcelVersion := "0.1.8-SNAPSHOT",
   version := s"${sparkVersion.value}_${sparkExcelVersion.value}",
   scalaVersion := {
     if (sparkVersion.value < "3.2.0") {

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ Compile / packageBin / publishArtifact := false
 Compile / packageDoc / publishArtifact := false
 Compile / packageSrc / publishArtifact := false
 
-artifactName := { (sv: ScalaVersion, module: ModuleID, artifact: Artifact) =>
+artifactName := { (_: ScalaVersion, _: ModuleID, artifact: Artifact) =>
   s"${artifact.name}-${(ThisBuild / version).value}.${artifact.extension}"
 }
 
@@ -57,8 +57,8 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % Provided,
   "org.apache.poi" % "poi" % poiVersion.value % Compile,
   "org.apache.poi" % "poi-ooxml" % poiVersion.value % Compile,
-  "org.apache.poi" % "poi-ooxml-schemas" % poiVersion.value % Compile,
-  "org.apache.commons" % "commons-compress" % "1.20" % Compile,
+  "org.apache.poi" % "poi-ooxml-full" % poiVersion.value % Compile,
+  "org.apache.commons" % "commons-compress" % "1.21" % Compile,
   "org.apache.commons" % "commons-collections4" % "4.4" % Compile
 )
 
@@ -121,6 +121,6 @@ val commonSettings = Seq(
     }
   },
   scalaTestVersion := "3.2.9",
-  poiVersion := "4.1.2",
+  poiVersion := "5.2.0",
   crossVersion := CrossVersion.disabled
 )

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ addArtifact(Compile / assembly / artifact, assembly)
 
 // Define common settings for the library
 val commonSettings = Seq(
-  sparkVersion := System.getProperty("sparkVersion", "3.2.0"),
+  sparkVersion := System.getProperty("sparkVersion", "3.2.1"),
   sparkExcelVersion := "0.1.8-SNAPSHOT",
   version := s"${sparkVersion.value}_${sparkExcelVersion.value}",
   scalaVersion := {

--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,8 @@ libraryDependencies ++= Seq(
   "org.apache.poi" % "poi-ooxml" % poiVersion.value % Compile,
   "org.apache.poi" % "poi-ooxml-lite" % poiVersion.value % Compile,
   "org.apache.commons" % "commons-compress" % "1.21" % Compile,
-  "org.apache.commons" % "commons-collections4" % "4.4" % Compile
+  "org.apache.commons" % "commons-collections4" % "4.4" % Compile,
+  "commons-io" % "commons-io" % "2.8.0" % Compile
 )
 
 // Setup test dependencies and configuration
@@ -81,7 +82,8 @@ ThisBuild / assemblyShadeRules := Seq(
   ShadeRule.rename("org.apache.poi.**" -> "elastashade.poi.@1").inAll,
   ShadeRule.rename("org.apache.commons.collections4.**" -> "elastashade.commons.collections4.@1").inAll,
   ShadeRule.rename("org.apache.commons.compress.**" -> "elastashade.commons.compress.@1").inAll,
-  ShadeRule.rename("org.apache.logging.log4j.**" -> "elastashade.logging.log4j.@1").inAll
+  ShadeRule.rename("org.apache.logging.log4j.**" -> "elastashade.logging.log4j.@1").inAll,
+  ShadeRule.rename("org.apache.commons.io.**" -> "elastashade.commons.io.@1").inAll
 )
 
 ThisBuild / assemblyMergeStrategy := {
@@ -89,6 +91,7 @@ ThisBuild / assemblyMergeStrategy := {
   case PathList("META-INF", "services", _@_*) => MergeStrategy.first
   case PathList("com", "elastacloud", _@_*) => MergeStrategy.last
   case PathList("elastashade", "poi", _@_*) => MergeStrategy.last
+  case PathList("elastashade", "commons", "io", _@_*) => MergeStrategy.last
   case PathList("elastashade", "commons", "compress", _@_*) => MergeStrategy.last
   case PathList("elastashade", "commons", "collections4", _@_*) => MergeStrategy.last
   case PathList("elastashade", "logging", "log4j", _@_*) => MergeStrategy.last

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % sparkVersion.value % Provided,
   "org.apache.poi" % "poi" % poiVersion.value % Compile,
   "org.apache.poi" % "poi-ooxml" % poiVersion.value % Compile,
-  "org.apache.poi" % "poi-ooxml-full" % poiVersion.value % Compile,
+  "org.apache.poi" % "poi-ooxml-lite" % poiVersion.value % Compile,
   "org.apache.commons" % "commons-compress" % "1.21" % Compile,
   "org.apache.commons" % "commons-collections4" % "4.4" % Compile
 )
@@ -80,15 +80,18 @@ coverageHighlighting := true
 ThisBuild / assemblyShadeRules := Seq(
   ShadeRule.rename("org.apache.poi.**" -> "elastashade.poi.@1").inAll,
   ShadeRule.rename("org.apache.commons.collections4.**" -> "elastashade.commons.collections4.@1").inAll,
-  ShadeRule.rename("org.apache.commons.compress.**" -> "elastashade.commons.compress.@1").inAll
+  ShadeRule.rename("org.apache.commons.compress.**" -> "elastashade.commons.compress.@1").inAll,
+  ShadeRule.rename("org.apache.logging.log4j.**" -> "elastashade.logging.log4j.@1").inAll
 )
 
 ThisBuild / assemblyMergeStrategy := {
-  case PathList("META-INF", "services", "org.apache.spark.sql.sources.DataSourceRegister") => MergeStrategy.concat
+  //case PathList("META-INF", "services", "org.apache.spark.sql.sources.DataSourceRegister") => MergeStrategy.concat
+  case PathList("META-INF", "services", _@_*) => MergeStrategy.first
   case PathList("com", "elastacloud", _@_*) => MergeStrategy.last
   case PathList("elastashade", "poi", _@_*) => MergeStrategy.last
   case PathList("elastashade", "commons", "compress", _@_*) => MergeStrategy.last
   case PathList("elastashade", "commons", "collections4", _@_*) => MergeStrategy.last
+  case PathList("elastashade", "logging", "log4j", _@_*) => MergeStrategy.last
   case PathList("org", "apache", "xmlbeans", _@_*) => MergeStrategy.last
   case PathList("org", "openxmlformats", "schemas", _@_*) => MergeStrategy.last
   case PathList("schemaorg_apache_xmlbeans", _@_*) => MergeStrategy.last

--- a/src/main/scala/com/elastacloud/spark/excel/parser/ExcelParser.scala
+++ b/src/main/scala/com/elastacloud/spark/excel/parser/ExcelParser.scala
@@ -17,9 +17,11 @@
 package com.elastacloud.spark.excel.parser
 
 import com.elastacloud.spark.excel.ExcelParserOptions
+import org.apache.poi.hssf.usermodel.HSSFWorkbookFactory
 import org.apache.poi.openxml4j.util.ZipSecureFile
 import org.apache.poi.ss.usermodel._
 import org.apache.poi.ss.util.CellAddress
+import org.apache.poi.xssf.usermodel.XSSFWorkbookFactory
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
@@ -369,6 +371,14 @@ private[excel] class ExcelParser(inputStream: InputStream, options: ExcelParserO
 }
 
 object ExcelParser {
+  // Make sure that the correct providers are added. Adding this to the object as we can encounter
+  // a concurrent modification error if this happens in the class
+  WorkbookFactory.removeProvider(classOf[HSSFWorkbookFactory])
+  WorkbookFactory.removeProvider(classOf[XSSFWorkbookFactory])
+
+  WorkbookFactory.addProvider(new HSSFWorkbookFactory)
+  WorkbookFactory.addProvider(new XSSFWorkbookFactory)
+
   /**
    * Read the schema from an Excel workbook based on user defined [[ExcelParserOptions]]
    *

--- a/src/test/resources/Parser/ConcatString.xlsx
+++ b/src/test/resources/Parser/ConcatString.xlsx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16e884fec7ae0d19e181c2349544025f63832ecd6d5114b267cf782cfe3e2a07
+size 9317

--- a/src/test/scala/com/elastacloud/spark/excel/DefaultSourceTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/DefaultSourceTests.scala
@@ -17,7 +17,7 @@
 package com.elastacloud.spark.excel
 
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -138,6 +138,26 @@ class DefaultSourceTests extends AnyFlatSpec with Matchers with BeforeAndAfterAl
       .load(inputPath)
 
     df.count() should be(3)
+    df.schema should equal(dataSchema)
+  }
+
+  it should "apply the schema for basic non-native Excel data types" in {
+    val inputPath = testFilePath("/Parser/CalculatedData.xlsx")
+
+    val dataSchema = StructType(Array(
+      StructField("Col_A", IntegerType, nullable = true),
+      StructField("Col_B", DateType, nullable = true),
+      StructField("Col_C", FloatType, nullable = true),
+      StructField("Col_D", DateType, nullable = true),
+      StructField("Col_E", DoubleType, nullable = true)
+    ))
+
+    val df = spark.read
+      .format("com.elastacloud.spark.excel")
+      .schema(dataSchema)
+      .load(inputPath)
+
+    df.count() should be(10)
     df.schema should equal(dataSchema)
   }
 

--- a/src/test/scala/com/elastacloud/spark/excel/parser/ExcelParserTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/parser/ExcelParserTests.scala
@@ -268,6 +268,29 @@ class ExcelParserTests extends AnyFlatSpec with Matchers {
     }
   }
 
+  it should "Handle string concatenation formulas" in {
+    withInputStream("/Parser/ConcatString.xlsx") { inputStream =>
+      val expectedSchema = StructType(Array(
+        StructField("Title", StringType, nullable = true),
+        StructField("Given_Name", StringType, nullable = true),
+        StructField("Family_Name", StringType, nullable = true),
+        StructField("Full_Name", StringType, nullable = true)
+      ))
+
+      val expectedData = Seq(
+        Vector[Any]("Dr".asUnsafe, "Jennifer".asUnsafe, "Alagora".asUnsafe, "Dr Jennifer Alagora".asUnsafe),
+        Vector[Any]("Mr".asUnsafe, "Adam".asUnsafe, "Fox".asUnsafe, "Mr Adam Fox".asUnsafe),
+        Vector[Any]("Ms".asUnsafe, null, "Proctor".asUnsafe, "Ms Proctor".asUnsafe)
+      )
+
+      var parser = new ExcelParser(inputStream, ExcelParserOptions())
+      parser.readDataSchema() should equal(expectedSchema)
+
+      val actualData = parser.getDataIterator.toList
+      actualData should equal(expectedData)
+    }
+  }
+
   "Opening a workbook with blank cells" should "continue to be read without error" in {
     withInputStream("/Parser/SimpleWorkbookWithBlanks.xlsx") { inputStream =>
       val options = ExcelParserOptions()


### PR DESCRIPTION
Implements solutions to the following issues:

* #14 Upgrades to Apache POI 5.2.0, bring support for more formulae types for evaluation
* #15 adds support for standard Spark types which aren't native to Excel (e.g. long, DateTime, etc...)
* Adds Spark 3.1.3 and 3.2.1 to build profiles