### PR TITLE
Schema match checking

### DIFF
--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.1, 3.1.2, 3.1.3, 3.2.0, 3.2.1, 3.2.2, 3.3.0 ]
+        sparkVersion: [ 3.0.1, 3.0.2, 3.0.3, 3.1.2, 3.2.1, 3.2.4, 3.3.0, 3.3.1, 3.3.2 ]
 
     runs-on: ubuntu-latest
 

--- a/build.ps1
+++ b/build.ps1
@@ -14,7 +14,7 @@
     https://www.elastacloud.com
 #>
 
-$versions = @("3.0.1", "3.0.2", "3.0.3", "3.1.1", "3.1.2", "3.1.3", "3.2.0", "3.2.1")
+$versions = @("3.0.1", "3.0.2", "3.1.2", "3.2.1", "3.2.4", "3.3.0", "3.3.1", "3.3.2")
 $jarPath = "./target/jars"
 $covPath = "./target/coverage"
 

--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ addArtifact(Compile / assembly / artifact, assembly)
 
 // Define common settings for the library
 val commonSettings = Seq(
-  sparkVersion := System.getProperty("sparkVersion", "3.3.0"),
+  sparkVersion := System.getProperty("sparkVersion", "3.3.2"),
   sparkExcelVersion := "0.1.11-SNAPSHOT",
   version := s"${sparkVersion.value}_${sparkExcelVersion.value}",
   scalaVersion := {

--- a/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
+++ b/src/main/scala/com/elastacloud/spark/excel/ExcelParserOptions.scala
@@ -38,7 +38,9 @@ private[excel] case class ExcelParserOptions(workbookPassword: Option[String] = 
                                              headerRowCount: Int = 1,
                                              maxRowCount: Int = 1000,
                                              includeSheetName: Boolean = false,
-                                             thresholdBytesForTempFiles: Int = 100000000)
+                                             thresholdBytesForTempFiles: Int = 100000000,
+                                             schemaMatchColumnName: String = null
+                                            )
 
 private[excel] object ExcelParserOptions {
   private val encoder = new DoubleMetaphone()
@@ -54,7 +56,8 @@ private[excel] object ExcelParserOptions {
     encoder.encode("maxRowCount") -> "maxRowCount",
     encoder.encode("includeSheetName") -> "includeSheetName",
     encoder.encode("maxBytesForTempFiles") -> "maxBytesForTempFiles",
-    encoder.encode("thresholdBytesForTempFiles") -> "thresholdBytesForTempFiles"
+    encoder.encode("thresholdBytesForTempFiles") -> "thresholdBytesForTempFiles",
+    encoder.encode("schemaMatchColumnName") -> "schemaMatchColumnName"
   )
 
   /**
@@ -97,6 +100,11 @@ private[excel] object ExcelParserOptions {
 
     val thresholdBytesForTempFiles = options.getInt("thresholdBytesForTempFiles", options.getInt("maxBytesForTempFiles", 100000000))
 
+    val schemaMatchColumnName = options.getOrDefault("schemaMatchColumnName", null)
+    if (schemaMatchColumnName != null && schemaMatchColumnName.trim.isEmpty) {
+      throw new ExcelParserOptionsException("The 'schemaMatchColumnName' option must contain a value if provided")
+    }
+
     ExcelParserOptions(
       worksheetPassword,
       options.getOrDefault("sheetNamePattern", ""),
@@ -104,7 +112,8 @@ private[excel] object ExcelParserOptions {
       options.getInt("headerRowCount", 1),
       options.getInt("maxRowCount", 1000),
       options.getBoolean("includeSheetName", false),
-      thresholdBytesForTempFiles
+      thresholdBytesForTempFiles,
+      schemaMatchColumnName
     )
   }
 
@@ -128,6 +137,11 @@ private[excel] object ExcelParserOptions {
 
     val thresholdBytesForTempFiles = options.getOrElse("thresholdBytesForTempFiles", options.getOrElse("maxBytesForTempFiles", "100000000"))
 
+    val schemaMatchColumnName = options.getOrElse("schemaMatchColumnName", null)
+    if (schemaMatchColumnName != null && schemaMatchColumnName.trim.isEmpty) {
+      throw new ExcelParserOptionsException("The 'schemaMatchColumnName' option must contain a value if provided")
+    }
+
     ExcelParserOptions(
       worksheetPassword,
       options.getOrElse("sheetNamePattern", ""),
@@ -135,7 +149,8 @@ private[excel] object ExcelParserOptions {
       options.getOrElse("headerRowCount", "1").toInt,
       options.getOrElse("maxRowCount", "1000").toInt,
       options.getOrElse("includeSheetName", "false").toBoolean,
-      thresholdBytesForTempFiles.toInt
+      thresholdBytesForTempFiles.toInt,
+      schemaMatchColumnName
     )
   }
 }

--- a/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
+++ b/src/test/scala/com/elastacloud/spark/excel/ExcelParserOptionsTests.scala
@@ -17,6 +17,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.maxRowCount should be(1000)
     options.includeSheetName should be(false)
     options.thresholdBytesForTempFiles should be(100000000)
+    options.schemaMatchColumnName should be(null)
   }
 
   "Creating from a case insensitive map" should "use default values for an empty map" in {
@@ -31,6 +32,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.maxRowCount should be(1000)
     options.includeSheetName should be(false)
     options.thresholdBytesForTempFiles should be(100000000)
+    options.schemaMatchColumnName should be(null)
   }
 
   it should "extract values from the map" in {
@@ -41,7 +43,8 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
       "headerRowCount" -> "12",
       "maxRowCount" -> "2000",
       "includeSheetName" -> "true",
-      "maxBytesForTempFiles" -> "10"
+      "maxBytesForTempFiles" -> "10",
+      "schemaMatchColumnName" -> "_isValid"
     ).asJava)
 
     val options = ExcelParserOptions.from(input)
@@ -53,6 +56,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.maxRowCount should be(2000)
     options.includeSheetName should be(true)
     options.thresholdBytesForTempFiles should be(10)
+    options.schemaMatchColumnName should be("_isValid")
   }
 
   it should "provide useful error information if options are slightly mis-spelt" in {
@@ -63,7 +67,8 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
       "headerCount" -> "12",
       "maxRowCont" -> "2000",
       "includShetNam" -> "true",
-      "macsBitesTempFiles" -> "10"
+      "macsBitesTempFiles" -> "10",
+      "schemaMatchColumName" -> "_isValid"
     ).asJava)
 
     val exception = the[ExcelParserOptionsException] thrownBy ExcelParserOptions.from(input)
@@ -74,7 +79,8 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     exception.getMessage.contains("Invalid option 'headercount', did you mean 'headerRowCount'?") should be(true)
     exception.getMessage.contains("Invalid option 'maxrowcont', did you mean 'maxRowCount'?") should be(true)
     exception.getMessage.contains("Invalid option 'includshetnam', did you mean 'includeSheetName'?") should be(true)
-    exception.getMessage.contains("Invalid options 'macsBitesTempFiles', did you mean 'maxBytesForTempFiles'")
+    exception.getMessage.contains("Invalid option 'macsbitestempfiles', did you mean 'maxBytesForTempFiles'") should be(true)
+    exception.getMessage.contains("Invalid option 'schemamatchcolumname', did you mean 'schemaMatchColumnName'") should be(true)
   }
 
   it should "ignore options which are invalid and not close in spelling to valid options" in {
@@ -120,6 +126,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.maxRowCount should be(1000)
     options.includeSheetName should be(false)
     options.thresholdBytesForTempFiles should be(100000000)
+    options.schemaMatchColumnName should be(null)
   }
 
   it should "extract values from the map" in {
@@ -130,7 +137,8 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
       "headerRowCount" -> "12",
       "maxRowCount" -> "2000",
       "includeSheetName" -> "true",
-      "maxBytesForTempFiles" -> "100"
+      "maxBytesForTempFiles" -> "100",
+      "schemaMatchColumnName" -> "_isValid"
     )
 
     val options = ExcelParserOptions.from(input)
@@ -142,6 +150,7 @@ class ExcelParserOptionsTests extends AnyFlatSpec with Matchers {
     options.maxRowCount should be(2000)
     options.includeSheetName should be(true)
     options.thresholdBytesForTempFiles should be(100)
+    options.schemaMatchColumnName should be("_isValid")
   }
 
   it should "use thresholdBytesForTempFiles if maxBytesForTempFiles is not provided" in {


### PR DESCRIPTION
Introduces the functionality to have the parser inform the user if a generated row matches the supplied (or inferred) schema.

The change, using an inferred schema would operate in the following way.

Excel source
![image](https://github.com/elastacloud/spark-excel/assets/204848/fd9252db-39ac-4efb-86b8-3007664abe8d)

Example read
![image](https://github.com/elastacloud/spark-excel/assets/204848/a606e228-b745-4a2d-9ff8-f212988675c3)

Generated output
![image](https://github.com/elastacloud/spark-excel/assets/204848/98b22ff1-85b9-4e4e-90ef-f7efc9ec215b)
